### PR TITLE
fix: note alert in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ A Neovim plugin for creating and managing [presenterm](https://github.com/mfonta
 
 ### lazy.nvim
 
-> [!NOTE] lazy.nvim [auto-detects rockspec files](https://lazy.folke.io/packages#rockspec) and will try to [build via luarocks](https://lazy.folke.io/developers#building) by default. Since this is a pure Lua plugin that doesn't require compilation, add `build = false` to skip the build step and avoid needing lua5.1/luajit.
+> [!NOTE]
+> lazy.nvim [auto-detects rockspec files](https://lazy.folke.io/packages#rockspec) and will try to [build via luarocks](https://lazy.folke.io/developers#building) by default. Since this is a pure Lua plugin that doesn't require compilation, add `build = false` to skip the build step and avoid needing lua5.1/luajit.
 
 **Minimal setup (uses defaults):**
 ```lua


### PR DESCRIPTION
I noticed that the `[!NOTE]`-alert was not rendered correctly in your README.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts